### PR TITLE
Supernode: Bump Node version to 14

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  environment = { NODE_VERSION = "14.15.3" }
   command = "yarn build"
   functions = "functions"
   publish = "./public/"


### PR DESCRIPTION
This unblocks #38, which has a dependency on Node 14.