### PR TITLE
Fix Sign-In issues that happened because of address change in the wallet

### DIFF
--- a/manifesto-dapp-backend/functions/src/index.ts
+++ b/manifesto-dapp-backend/functions/src/index.ts
@@ -278,9 +278,7 @@ async function verifyToken(token: SignedMessage) {
 
   if (
     !["tally.cash", "localhost:8000"].includes(verified.domain) &&
-    !(
-      verified.domain.startsWith("tally") && verified.domain.endsWith("web.app")
-    )
+    !verified.domain.endsWith("tally-cash.netlify.app")
   ) {
     throw new HttpsError("invalid-argument", "Wrong domain", "Wrong domain");
   }

--- a/src/features/Manifesto/ManifestoPanel/ManifestoPanelWithTally/index.tsx
+++ b/src/features/Manifesto/ManifestoPanel/ManifestoPanelWithTally/index.tsx
@@ -110,7 +110,7 @@ export function ManifestoPanelWithTally({
                 disabled={!account || tokenIsLoading}
                 onClick={() => {
                   if (!account) throw new Error();
-                  signInWithEthereum(account);
+                  signInWithEthereum();
                 }}
               >
                 Sign-In with Ethereum

--- a/src/features/Manifesto/ManifestoPanel/ManifestoPanelWithTally/index.tsx
+++ b/src/features/Manifesto/ManifestoPanel/ManifestoPanelWithTally/index.tsx
@@ -122,7 +122,10 @@ export function ManifestoPanelWithTally({
               </Message>
             )}
             {siweAccount && userError && (
-              <Message isError>Cannot connect to our server.</Message>
+              <Message isError>
+                {(userError as { details?: string }).details ??
+                  "Cannot connect to our server."}
+              </Message>
             )}
           </Step>
 

--- a/src/features/Manifesto/hooks/useSIWE.tsx
+++ b/src/features/Manifesto/hooks/useSIWE.tsx
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { Account, SiweAccount } from "features/Manifesto/types";
+import { SiweAccount } from "features/Manifesto/types";
 import { useMutation } from "react-query";
 import { SiweMessage } from "siwe";
 
@@ -15,6 +15,14 @@ export function useSIWE() {
       }
 
       const provider = new ethers.providers.Web3Provider(tallyWindowProvider);
+
+      try {
+        await provider.send("eth_requestAccounts", []);
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
+
       const signer = provider.getSigner();
       const address = await signer.getAddress();
 


### PR DESCRIPTION
We need to use `HttpsError` from `firebase-functions/v1/https`
for the back-end to propagate the error to UI

We need to specify the error message 2x
because the 2nd one is set on the `details`
property and that property is accessible in
the component code.
(For some reason `useQuery` removes the
`message` property from the error object >
the reason of the problem is lost in the component`

Test:
- wallet change during the process between 2 connected wallets
  - sign > connect wallet A 
  - reload
  - sign > connect wallet B > switch to wallet A in extension > press Sign-in 
  - expected output: sign in is successful and it's possible to sign the pledge
    - NOT expected: the address of the connected account to change on the first step
- wallet change during the process from a connected to a not connected wallet 
  - sign > connect wallet B
  - switch to wallet A in extension (A should be an address that's not yet connected to the dapp)
  - press Sign in button
  - expected output: dapp connections modal shows > siwe signing window show > sign > log in happens
- offline 
  - load page 
  - chrome devtoolbar > network > throttling: offline
    - ![CleanShot 2022-08-25 at 20 43 25](https://user-images.githubusercontent.com/7690112/186667821-6f00fa31-a7bf-46f8-9b87-87792cb8a2f3.png)
  - sign > connect wallet A >  > press Sign in
  - expected output: ![CleanShot 2022-08-25 at 20 47 32](https://user-images.githubusercontent.com/7690112/186668647-6a865e3f-92b1-4d10-bd52-1964ecc84653.png)



