### PR TITLE
add matomo dl class to all chrome store links

### DIFF
--- a/src/features/Download/Cta/index.tsx
+++ b/src/features/Download/Cta/index.tsx
@@ -21,7 +21,7 @@ const firefoxDownloadHref = "/tally_ho_pre_release_channel-0.13.1-fx.xpi";
 export function DownloadCta() {
   return (
     <div
-      className={css`
+      className={"matomo_download " + css`
         padding: 3rem 0;
         display: flex;
         flex-flow: row wrap;

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -38,7 +38,7 @@ export function Header() {
           />
         </Link>
         <Link
-          className={css`
+          className={"matomo_download " + css`
             position: relative;
             margin: 0 0.75rem;
             color: inherit;

--- a/src/features/Home/Hero/index.tsx
+++ b/src/features/Home/Hero/index.tsx
@@ -78,7 +78,7 @@ export function HomeProductHero() {
             owned by its users.
           </p>
           <Link
-            className={css`
+            className={"matomo_download " + css`
               display: inline-block;
               padding: ${buttonBlockPadding} ${buttonInlinePadding};
               border-radius: ${buttonBorderRadius};


### PR DESCRIPTION
updating links to use a Matomo tracking class that consolidates stats on chrome store outbounds